### PR TITLE
Allow override of default aggressive indexing behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ animals
 
 This creates the database in Cloudant. If you are just connecting to a database that *silverlining* created for you last time, then there is no need for the `create` step.
 
+The `create` function both creates a database and also instructs Cloudant to index all fields of any documents that are added. This allows queries to be asked of any field in the database. If this behaviour is not required, then simply pass in `false` in the `indexAll` option e.g.
+
+```js
+animals.create({indexAll: false})
+```
+
 ### Adding documents
 
 Add a single document to a database with the `insert` function:

--- a/lib/db.js
+++ b/lib/db.js
@@ -26,7 +26,13 @@ module.exports = function(url, dbname) {
   };
 
   // create a new empty database
-  var create = function() {
+  var create = function(opts) {
+
+    // default behaviour is to index everything
+    if (!opts || (typeof opts ==='object' && typeof opts.indexAll !== 'boolean')) {
+      opts = { indexAll: true };
+    }
+
     // create a database
     var r = {
       method: 'put',
@@ -34,6 +40,12 @@ module.exports = function(url, dbname) {
       json: true
     };
     return request(r).then(function() {
+
+      // stop here if no indexing is required
+      if (!opts.indexAll) {
+        return {ok: true};
+      }
+
       // index everything
       var r = {
         method: 'post',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "silverlining",
-  "version": "1.20.0",
-  "description": "Simple NoSQL library",
+  "version": "1.21.0",
+  "description": "Simple Cloudant library",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha",

--- a/test/db.js
+++ b/test/db.js
@@ -50,6 +50,16 @@ describe('db', function() {
     });
   });
 
+  it('create - should create a database with no indexes if asked for', function() {
+    var mocks = nock(SERVER)
+      .put('/mydb').reply(200, {ok:true});
+    return nosql.create({indexAll: false}).then(function() {
+      assert(mocks.isDone());
+    }).catch(function(err) {
+      assert(false);
+    });
+  });
+
   it('create - should fail when db exists', function() {
     var mocks = nock(SERVER)
       .put('/mydb').reply(412, {ok:false, err:'failed', reason:'exists'});


### PR DESCRIPTION
allow `db.create({indexAll:false})` to be used prevent indexing of all fields in a database