### PR TITLE
1.23.4 - allow bigger limits

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -81,7 +81,7 @@ module.exports = function(url, dbname) {
     if (!opts) {
       opts = {};
     }
-    if (!opts.limit || opts.limit > 100) {
+    if (!opts.limit) {
       opts.limit = 100;
     }
     opts.include_docs = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silverlining",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "description": "Simple Cloudant library",
   "main": "index.js",
   "scripts": {

--- a/test/db.js
+++ b/test/db.js
@@ -217,7 +217,7 @@ describe('db', function() {
       ]
     };
     var mocks = nock(SERVER)
-      .get('/mydb/_all_docs?skip=100&limit=100&include_docs=true').reply(200, reply);
+      .get('/mydb/_all_docs?skip=100&limit=200&include_docs=true').reply(200, reply);
     return nosql.all({ skip:100, limit:200}).then(function(data) {
       assert.equal(data.length, 3);
       assert.equal(typeof data[0], 'object');


### PR DESCRIPTION
Allow all() to have unlimited limit, if supplied. Defaults to 100.